### PR TITLE
Network security

### DIFF
--- a/modules/chibisafe.nix
+++ b/modules/chibisafe.nix
@@ -58,7 +58,10 @@ in {
     forceLan = mkOption {
       type = types.bool;
       default = false;
-      description = "Force LAN access, ignoring router configuration.";
+      description = ''
+        Force LAN access, ignoring router configuration.
+        You will be able to access this container on <lan_ip>:${toString cfg.port} regardless of your router configuration.
+      '';
     };
 
     paths = {

--- a/modules/chibisafe.nix
+++ b/modules/chibisafe.nix
@@ -55,6 +55,12 @@ in {
       description = "Port to use for chibisafe";
     };
 
+    forceLan = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Force LAN access, ignoring router configuration.";
+    };
+
     paths = {
       default = helpers.mkInheritedPathOption {
         parentName = "home server global default path";
@@ -111,7 +117,7 @@ in {
 
       chibisafe_caddy = {
         image = "caddy:2-alpine";
-        ports = [ "${if config.homeserver.routing.lan then "" else "127.0.0.1:"}${toString cfg.port}:80" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:80" ];
         environment = { BASE_URL = ":80"; };
         volumes = [
           "${cfg.paths.uploads}:/app/uploads:ro"

--- a/modules/chibisafe.nix
+++ b/modules/chibisafe.nix
@@ -120,7 +120,7 @@ in {
 
       chibisafe_caddy = {
         image = "caddy:2-alpine";
-        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}80" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:80" ];
         environment = { BASE_URL = ":80"; };
         volumes = [
           "${cfg.paths.uploads}:/app/uploads:ro"

--- a/modules/chibisafe.nix
+++ b/modules/chibisafe.nix
@@ -120,7 +120,7 @@ in {
 
       chibisafe_caddy = {
         image = "caddy:2-alpine";
-        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:80" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}80" ];
         environment = { BASE_URL = ":80"; };
         volumes = [
           "${cfg.paths.uploads}:/app/uploads:ro"

--- a/modules/chibisafe.nix
+++ b/modules/chibisafe.nix
@@ -55,14 +55,10 @@ in {
       description = "Port to use for chibisafe";
     };
 
-    forceLan = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
+    forceLan = mkEnableOption ''
         Force LAN access, ignoring router configuration.
         You will be able to access this container on <lan_ip>:${toString cfg.port} regardless of your router configuration.
-      '';
-    };
+    '';
 
     paths = {
       default = helpers.mkInheritedPathOption {

--- a/modules/immich.nix
+++ b/modules/immich.nix
@@ -82,7 +82,7 @@ in {
     virtualisation.oci-containers.containers = {
       immich = {
         image = "ghcr.io/immich-app/immich-server:${cfg.version}";
-        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:2283" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}2283" ];
         environment = {
           IMMICH_VERSION = toString cfg.version;
           DB_HOSTNAME = "immich_postgres";

--- a/modules/immich.nix
+++ b/modules/immich.nix
@@ -82,7 +82,7 @@ in {
     virtualisation.oci-containers.containers = {
       immich = {
         image = "ghcr.io/immich-app/immich-server:${cfg.version}";
-        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}2283" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:2283" ];
         environment = {
           IMMICH_VERSION = toString cfg.version;
           DB_HOSTNAME = "immich_postgres";

--- a/modules/immich.nix
+++ b/modules/immich.nix
@@ -27,6 +27,12 @@ in {
       description = "Port to use for Immich";
     };
 
+    forceLan = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Force LAN access, ignoring router configuration.";
+    };
+
     subdomain = mkOption {
       type = types.str;
       default = "immich";
@@ -73,7 +79,7 @@ in {
     virtualisation.oci-containers.containers = {
       immich = {
         image = "ghcr.io/immich-app/immich-server:${cfg.version}";
-        ports = [ "${if config.homeserver.routing.lan then "" else "127.0.0.1:"}${toString cfg.port}:2283" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:2283" ];
         environment = {
           IMMICH_VERSION = toString cfg.version;
           DB_HOSTNAME = "immich_postgres";

--- a/modules/immich.nix
+++ b/modules/immich.nix
@@ -30,7 +30,10 @@ in {
     forceLan = mkOption {
       type = types.bool;
       default = false;
-      description = "Force LAN access, ignoring router configuration.";
+      description = ''
+        Force LAN access, ignoring router configuration.
+        You will be able to access this container on <lan_ip>:${toString cfg.port} regardless of your router configuration.
+      '';
     };
 
     subdomain = mkOption {

--- a/modules/immich.nix
+++ b/modules/immich.nix
@@ -27,14 +27,10 @@ in {
       description = "Port to use for Immich";
     };
 
-    forceLan = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
+    forceLan = mkEnableOption ''
         Force LAN access, ignoring router configuration.
         You will be able to access this container on <lan_ip>:${toString cfg.port} regardless of your router configuration.
-      '';
-    };
+    '';
 
     subdomain = mkOption {
       type = types.str;

--- a/modules/jellyfin.nix
+++ b/modules/jellyfin.nix
@@ -67,7 +67,7 @@ in {
     virtualisation.oci-containers.containers = {
       jellyfin = {
         image = "jellyfin/jellyfin:${cfg.version}";
-        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}8096" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:8096" ];
         volumes = [
           #"${jellyfinRoot}/media:/media"
           "${cfg.paths.media}:/media"

--- a/modules/jellyfin.nix
+++ b/modules/jellyfin.nix
@@ -30,7 +30,10 @@ in {
     forceLan = mkOption {
       type = types.bool;
       default = false;
-      description = "Force LAN access, ignoring router configuration.";
+      description = ''
+        Force LAN access, ignoring router configuration.
+        You will be able to access this container on <lan_ip>:${toString cfg.port} regardless of your router configuration.
+      '';
     };
 
     paths = {

--- a/modules/jellyfin.nix
+++ b/modules/jellyfin.nix
@@ -27,6 +27,12 @@ in {
       description = "Port to use for Jellyfin";
     };
 
+    forceLan = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Force LAN access, ignoring router configuration.";
+    };
+
     paths = {
       default = helpers.mkInheritedPathOption {
         parentName = "home server global default path";
@@ -58,7 +64,7 @@ in {
     virtualisation.oci-containers.containers = {
       jellyfin = {
         image = "jellyfin/jellyfin:${cfg.version}";
-        ports = [ "${if config.homeserver.routing.lan then "" else "127.0.0.1:"}${toString cfg.port}:8096" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:8096" ];
         volumes = [
           #"${jellyfinRoot}/media:/media"
           "${cfg.paths.media}:/media"

--- a/modules/jellyfin.nix
+++ b/modules/jellyfin.nix
@@ -67,7 +67,7 @@ in {
     virtualisation.oci-containers.containers = {
       jellyfin = {
         image = "jellyfin/jellyfin:${cfg.version}";
-        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:8096" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}8096" ];
         volumes = [
           #"${jellyfinRoot}/media:/media"
           "${cfg.paths.media}:/media"

--- a/modules/jellyfin.nix
+++ b/modules/jellyfin.nix
@@ -27,14 +27,10 @@ in {
       description = "Port to use for Jellyfin";
     };
 
-    forceLan = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
+    forceLan = mkEnableOption ''
         Force LAN access, ignoring router configuration.
         You will be able to access this container on <lan_ip>:${toString cfg.port} regardless of your router configuration.
-      '';
-    };
+    '';
 
     paths = {
       default = helpers.mkInheritedPathOption {

--- a/modules/openspeedtest.nix
+++ b/modules/openspeedtest.nix
@@ -20,6 +20,12 @@ in {
       description = "Port to use for OpenSpeedTest";
     };
 
+    forceLan = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Force LAN access, ignoring router configuration.";
+    };
+
     subdomain = mkOption {
       type = types.str;
       default = "openspeedtest";
@@ -35,7 +41,7 @@ in {
     virtualisation.oci-containers.containers = {
       openspeedtest = {
         image = "openspeedtest/${cfg.version}";
-        ports = [ "${if config.homeserver.routing.lan then "" else "127.0.0.1:"}${toString cfg.port}:3000" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:3000" ];
       };
     };
   };

--- a/modules/openspeedtest.nix
+++ b/modules/openspeedtest.nix
@@ -44,7 +44,7 @@ in {
     virtualisation.oci-containers.containers = {
       openspeedtest = {
         image = "openspeedtest/${cfg.version}";
-        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:3000" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}3000" ];
       };
     };
   };

--- a/modules/openspeedtest.nix
+++ b/modules/openspeedtest.nix
@@ -44,7 +44,7 @@ in {
     virtualisation.oci-containers.containers = {
       openspeedtest = {
         image = "openspeedtest/${cfg.version}";
-        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}3000" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:3000" ];
       };
     };
   };

--- a/modules/openspeedtest.nix
+++ b/modules/openspeedtest.nix
@@ -23,7 +23,10 @@ in {
     forceLan = mkOption {
       type = types.bool;
       default = false;
-      description = "Force LAN access, ignoring router configuration.";
+      description = ''
+        Force LAN access, ignoring router configuration.
+        You will be able to access this container on <lan_ip>:${toString cfg.port} regardless of your router configuration.
+      '';
     };
 
     subdomain = mkOption {

--- a/modules/openspeedtest.nix
+++ b/modules/openspeedtest.nix
@@ -20,14 +20,10 @@ in {
       description = "Port to use for OpenSpeedTest";
     };
 
-    forceLan = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
+    forceLan = mkEnableOption ''
         Force LAN access, ignoring router configuration.
         You will be able to access this container on <lan_ip>:${toString cfg.port} regardless of your router configuration.
-      '';
-    };
+    '';
 
     subdomain = mkOption {
       type = types.str;

--- a/modules/psitransfer.nix
+++ b/modules/psitransfer.nix
@@ -27,6 +27,12 @@ in {
       description = "Port to use for Psitransfer";
     };
 
+    forceLan = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Force LAN access, ignoring router configuration.";
+    };
+
     paths = {
       default = helpers.mkInheritedPathOption {
         parentName = "home server global default path";
@@ -55,7 +61,7 @@ in {
     virtualisation.oci-containers.containers = {
       psitransfer = {
         image = "psitrax/psitransfer:${cfg.version}";
-        ports = [ "${if config.homeserver.routing.lan then "" else "127.0.0.1:"}${toString cfg.port}:3000" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:3000" ];
         environment = {
           PUID="0";
           PGID="0";

--- a/modules/psitransfer.nix
+++ b/modules/psitransfer.nix
@@ -27,14 +27,10 @@ in {
       description = "Port to use for Psitransfer";
     };
 
-    forceLan = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
+    forceLan = mkEnableOption ''
         Force LAN access, ignoring router configuration.
         You will be able to access this container on <lan_ip>:${toString cfg.port} regardless of your router configuration.
-      '';
-    };
+    '';
 
     paths = {
       default = helpers.mkInheritedPathOption {

--- a/modules/psitransfer.nix
+++ b/modules/psitransfer.nix
@@ -30,7 +30,10 @@ in {
     forceLan = mkOption {
       type = types.bool;
       default = false;
-      description = "Force LAN access, ignoring router configuration.";
+      description = ''
+        Force LAN access, ignoring router configuration.
+        You will be able to access this container on <lan_ip>:${toString cfg.port} regardless of your router configuration.
+      '';
     };
 
     paths = {

--- a/modules/psitransfer.nix
+++ b/modules/psitransfer.nix
@@ -64,7 +64,7 @@ in {
     virtualisation.oci-containers.containers = {
       psitransfer = {
         image = "psitrax/psitransfer:${cfg.version}";
-        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}3000" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:3000" ];
         environment = {
           PUID="0";
           PGID="0";

--- a/modules/psitransfer.nix
+++ b/modules/psitransfer.nix
@@ -64,7 +64,7 @@ in {
     virtualisation.oci-containers.containers = {
       psitransfer = {
         image = "psitrax/psitransfer:${cfg.version}";
-        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:3000" ];
+        ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}3000" ];
         environment = {
           PUID="0";
           PGID="0";

--- a/modules/routing.nix
+++ b/modules/routing.nix
@@ -65,8 +65,7 @@ in
     services.nginx = {
       enable = true;
 
-      # TODO: also enable without letsencrypt ?
-      appendHttpConfig = mkIf cfg.letsencrypt.enable strings.concatStringSep "\n" [
+      appendHttpConfig = strings.concatStringSep "\n" [
       ''
         add_header X-Frame-Options "SAMEORIGIN";
         add_header X-Content-Type-Options "nosniff";

--- a/modules/routing.nix
+++ b/modules/routing.nix
@@ -42,7 +42,6 @@ in
     services.nginx = {
       enable = true;
 
-      # TODO - can listen on lan by listening to 0.0.0.0
       virtualHosts = listToAttrs (lists.forEach webservices
         (module:
           attrsets.nameValuePair "${module.subdomain}.${cfg.domain}" {
@@ -51,7 +50,6 @@ in
             locations."/" = {
               proxyPass = "http://127.0.0.1:${toString module.port}";
             };
-            # TODO - tune values
             extraConfig = ''
               client_max_body_size 35M;
             '';
@@ -67,7 +65,6 @@ in
       defaults.server = mkIf cfg.letsencrypt.test-mode "https://acme-staging-v02.api.letsencrypt.org/directory";
     };
 
-    # FIXME - why still accessible with containers ports ?
     networking.firewall = {
       allowedTCPPorts = [ 80 443 ];
     };

--- a/modules/transmission.nix
+++ b/modules/transmission.nix
@@ -80,7 +80,7 @@ in {
       ];
 
       environmentFiles = [ cfg.environmentFile ];
-      ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:9091" ];
+      ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}9091" ];
     };
   };
 }

--- a/modules/transmission.nix
+++ b/modules/transmission.nix
@@ -56,14 +56,10 @@ in {
       description = "Port to use for Transmission";
     };
 
-    forceLan = mkOption {
-      type = types.bool;
-      default = false;
-      description = ''
+    forceLan = mkEnableOption ''
         Force LAN access, ignoring router configuration.
         You will be able to access this container on <lan_ip>:${toString cfg.port} regardless of your router configuration.
-      '';
-    };
+    '';
   };
 
   config = mkIf cfg.enable {

--- a/modules/transmission.nix
+++ b/modules/transmission.nix
@@ -59,7 +59,10 @@ in {
     forceLan = mkOption {
       type = types.bool;
       default = false;
-      description = "Force LAN access, ignoring router configuration.";
+      description = ''
+        Force LAN access, ignoring router configuration.
+        You will be able to access this container on <lan_ip>:${toString cfg.port} regardless of your router configuration.
+      '';
     };
   };
 

--- a/modules/transmission.nix
+++ b/modules/transmission.nix
@@ -55,6 +55,12 @@ in {
       defaultText = "10003";
       description = "Port to use for Transmission";
     };
+
+    forceLan = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Force LAN access, ignoring router configuration.";
+    };
   };
 
   config = mkIf cfg.enable {
@@ -71,7 +77,7 @@ in {
       ];
 
       environmentFiles = [ cfg.environmentFile ];
-      ports = [ "${if config.homeserver.routing.lan then "" else "127.0.0.1:"}${toString cfg.port}:9091" ];
+      ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:9091" ];
     };
   };
 }

--- a/modules/transmission.nix
+++ b/modules/transmission.nix
@@ -80,7 +80,7 @@ in {
       ];
 
       environmentFiles = [ cfg.environmentFile ];
-      ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}9091" ];
+      ports = [ "${if (config.homeserver.routing.lan || cfg.forceLan) then "" else "127.0.0.1:"}${toString cfg.port}:9091" ];
     };
   };
 }


### PR DESCRIPTION
Added options to:
- Hide containers from lan when routing is enabled
- Show them with an override (a global override in the router, or one for each webservice)
- Security http headers
- Filter clients with a certificate (ensure requests are coming from a trusted proxy)